### PR TITLE
add `From<&[u8]>` from `Value`

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -491,6 +491,12 @@ impl From<&str> for Value {
     }
 }
 
+impl From<&[u8]> for Value {
+    fn from(s: &[u8]) -> Self {
+        Self::from_bytes(s)
+    }
+}
+
 impl From<ValueRef<'_>> for Value {
     fn from(v: ValueRef<'_>) -> Self {
         Self::from_builder(v.capacity() + 4, |b| b.add_value(v))


### PR DESCRIPTION
Although we already have had `form_bytes()` in `Value`, a `From<&[u8]>` function helps unify the interfaces.