### PR TITLE
refactor: disallow constructing `ValueRef` by making enum a private field

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -321,10 +321,12 @@ impl<W: AsMut<Vec<u8>>> Builder<W> {
 
     /// Adds a JSON value to the builder.
     pub fn add_value(&mut self, value: ValueRef<'_>) {
-        match value {
-            ValueRef::Null => self.add_null(),
-            ValueRef::Bool(b) => self.add_bool(b),
-            ValueRef::Number(n) => {
+        use ValueRefVariant::*;
+
+        match value.variant() {
+            Null => self.add_null(),
+            Bool(b) => self.add_bool(b),
+            Number(n) => {
                 if let Some(i) = n.as_u64() {
                     self.add_u64(i)
                 } else if let Some(i) = n.as_i64() {
@@ -335,14 +337,14 @@ impl<W: AsMut<Vec<u8>>> Builder<W> {
                     panic!("invalid number");
                 }
             }
-            ValueRef::String(s) => self.add_string(s),
-            ValueRef::Array(a) => {
+            String(s) => self.add_string(s),
+            Array(a) => {
                 let buffer = self.buffer.as_mut();
                 buffer.extend_from_slice(a.as_slice());
                 let offset = self.offset();
                 self.pointers.push(Entry::array(offset));
             }
-            ValueRef::Object(o) => {
+            Object(o) => {
                 let buffer = self.buffer.as_mut();
                 buffer.extend_from_slice(o.as_slice());
                 let offset = self.offset();

--- a/src/partial_eq.rs
+++ b/src/partial_eq.rs
@@ -14,7 +14,7 @@
 
 //! `PartialEq` implementations for `ValueRef` and `Value`.
 
-use crate::ValueRef;
+use crate::{ValueRef, ValueRefVariant};
 
 use super::Value;
 
@@ -27,8 +27,8 @@ fn eq_u64(value: ValueRef<'_>, other: u64) -> bool {
 }
 
 fn eq_f32(value: ValueRef<'_>, other: f32) -> bool {
-    match value {
-        ValueRef::Number(n) => n.as_f32().map_or(false, |i| i == other),
+    match value.variant() {
+        ValueRefVariant::Number(n) => n.as_f32().map_or(false, |i| i == other),
         _ => false,
     }
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -44,13 +44,15 @@ impl ser::Serialize for ValueRef<'_> {
     where
         S: ::serde::Serializer,
     {
-        match self {
-            Self::Null => serializer.serialize_unit(),
-            Self::Bool(b) => serializer.serialize_bool(*b),
-            Self::Number(n) => n.serialize(serializer),
-            Self::String(s) => serializer.serialize_str(s),
-            Self::Array(v) => v.serialize(serializer),
-            Self::Object(o) => o.serialize(serializer),
+        use super::ValueRefVariant::*;
+
+        match self.variant() {
+            Null => serializer.serialize_unit(),
+            Bool(b) => serializer.serialize_bool(b),
+            Number(n) => n.serialize(serializer),
+            String(s) => serializer.serialize_str(s),
+            Array(v) => v.serialize(serializer),
+            Object(o) => o.serialize(serializer),
         }
     }
 }


### PR DESCRIPTION
Fix #6. This is a breaking change on API.