### PR TITLE
introduce `arbitrary_precision` feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ env:
 jobs:
   fmt:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        feature_args: ["", "--all-features"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -30,13 +33,14 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --all-targets --all-features -- -D warnings
+          args: --all-targets ${{ matrix.feature_args }} -- -D warnings
 
   test:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         toolchain: [stable, nightly]
+        feature_args: ["", "--all-features"]
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -47,12 +51,12 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --all-targets --all-features
+          args: --all-targets ${{ matrix.feature_args }}
       - name: Test
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --all-features --no-fail-fast
+          args: --no-fail-fast ${{ matrix.feature_args }}
 
   fuzz:
     name: fuzz (${{ matrix.fuzz_target }})
@@ -64,6 +68,8 @@ jobs:
             feature_args: ""
           - fuzz_target: roundtrip
             feature_args: "--features jsonbb/float_roundtrip"
+          - fuzz_target: roundtrip_ap
+            feature_args: "--features jsonbb/arbitrary_precision"
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
+arbitrary_precision = ["serde_json/arbitrary_precision"]
 float_roundtrip = ["serde_json/float_roundtrip"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,23 @@ license = "Apache-2.0"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [features]
-arbitrary_precision = ["serde_json/arbitrary_precision"]
+# Use sufficient precision when parsing fixed precision floats from JSON to
+# ensure that they maintain accuracy when round-tripped through JSON. This comes
+# at an approximately 2x performance cost for parsing floats compared to the
+# default best-effort precision.
+#
+# Unlike arbitrary_precision, this feature makes f64 -> JSON -> f64 produce
+# output identical to the input.
 float_roundtrip = ["serde_json/float_roundtrip"]
+
+# Use an arbitrary precision number representation for jsonbb::NumberRef. This
+# allows JSON numbers of arbitrary size/precision to be read into a NumberRef and
+# written back to a JSON string without loss of precision.
+#
+# Unlike float_roundtrip, this feature makes JSON -> jsonbb::NumberRef -> JSON
+# produce output identical to the input.
+arbitrary_precision = ["serde_json/arbitrary_precision"]
+
 
 [dependencies]
 bytes = "1"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -31,3 +31,10 @@ path = "fuzz_targets/roundtrip.rs"
 test = false
 doc = false
 required-features = ["jsonbb/float_roundtrip"]
+
+[[bin]]
+name = "roundtrip_ap"
+path = "fuzz_targets/roundtrip_ap.rs"
+test = false
+doc = false
+required-features = ["jsonbb/arbitrary_precision"]

--- a/fuzz/fuzz_targets/roundtrip_ap.rs
+++ b/fuzz/fuzz_targets/roundtrip_ap.rs
@@ -1,0 +1,27 @@
+#![no_main]
+
+use jsonbb::Value;
+use libfuzzer_sys::fuzz_target;
+use std::str::FromStr as _;
+
+fuzz_target!(|data: &[u8]| {
+    let Ok(original) = std::str::from_utf8(data) else {
+        return;
+    };
+    let Ok(_) = f64::from_str(original) else {
+        return;
+    };
+    let original = original
+        .replace(|c: char| c.is_whitespace(), "")
+        .replace("-0", "0");
+
+    let Ok(value) = Value::from_str(&original) else {
+        return;
+    };
+    let roundtripped = value.to_string();
+
+    assert_eq!(
+        original, roundtripped,
+        "original: {original}\nroundtripped: {roundtripped}"
+    );
+});

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -280,7 +280,7 @@ impl<W: AsMut<Vec<u8>>> Builder<W> {
                 let (k, v) = &mut entries[i];
                 let begin = k.offset();
                 let end = if v.is_number() {
-                    v.offset() + 1 + number_size(data[v.offset()])
+                    v.offset() + 1 + number_size(&data[v.offset()..])
                 } else if v.is_string() {
                     v.offset() + 4 + (&data[v.offset()..]).get_u32_ne() as usize
                 } else if v.is_array() || v.is_object() {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -98,7 +98,7 @@ impl<W: AsMut<Vec<u8>>> Builder<W> {
         let offset = self.offset();
         self.pointers.push(Entry::number(offset));
         let buffer = self.buffer.as_mut();
-        buffer.push(NUMBER_U64);
+        buffer.push(NumberTag::U64 as u8);
         buffer.put_u64_ne(v);
     }
 
@@ -108,18 +108,18 @@ impl<W: AsMut<Vec<u8>>> Builder<W> {
         self.pointers.push(Entry::number(offset));
         let buffer = self.buffer.as_mut();
         if v == 0 {
-            buffer.push(NUMBER_ZERO);
+            buffer.push(NumberTag::Zero as u8);
         } else if let Ok(v) = i8::try_from(v) {
-            buffer.push(NUMBER_I8);
+            buffer.push(NumberTag::I8 as u8);
             buffer.put_i8(v);
         } else if let Ok(v) = i16::try_from(v) {
-            buffer.push(NUMBER_I16);
+            buffer.push(NumberTag::I16 as u8);
             buffer.put_i16_ne(v);
         } else if let Ok(v) = i32::try_from(v) {
-            buffer.push(NUMBER_I32);
+            buffer.push(NumberTag::I32 as u8);
             buffer.put_i32_ne(v);
         } else {
-            buffer.push(NUMBER_I64);
+            buffer.push(NumberTag::I64 as u8);
             buffer.put_i64_ne(v);
         }
     }
@@ -133,7 +133,7 @@ impl<W: AsMut<Vec<u8>>> Builder<W> {
         let offset = self.offset();
         self.pointers.push(Entry::number(offset));
         let buffer = self.buffer.as_mut();
-        buffer.push(NUMBER_F64);
+        buffer.push(NumberTag::F64 as u8);
         buffer.put_f64_ne(v);
     }
 

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -120,13 +120,40 @@ impl From<&[u8]> for Entry {
 }
 
 // last 4 bits is the size
-pub const NUMBER_ZERO: u8 = 0x0;
-pub const NUMBER_I8: u8 = 0x1;
-pub const NUMBER_I16: u8 = 0x2;
-pub const NUMBER_I32: u8 = 0x4;
-pub const NUMBER_I64: u8 = 0x8;
-pub const NUMBER_U64: u8 = 0x18;
-pub const NUMBER_F64: u8 = 0x28;
+const NUMBER_ZERO: u8 = 0x0;
+const NUMBER_I8: u8 = 0x1;
+const NUMBER_I16: u8 = 0x2;
+const NUMBER_I32: u8 = 0x4;
+const NUMBER_I64: u8 = 0x8;
+const NUMBER_U64: u8 = 0x18;
+const NUMBER_F64: u8 = 0x28;
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum NumberTag {
+    Zero = NUMBER_ZERO,
+    I8 = NUMBER_I8,
+    I16 = NUMBER_I16,
+    I32 = NUMBER_I32,
+    I64 = NUMBER_I64,
+    U64 = NUMBER_U64,
+    F64 = NUMBER_F64,
+}
+
+impl From<u8> for NumberTag {
+    fn from(v: u8) -> Self {
+        match v {
+            NUMBER_ZERO => Self::Zero,
+            NUMBER_I8 => Self::I8,
+            NUMBER_I16 => Self::I16,
+            NUMBER_I32 => Self::I32,
+            NUMBER_I64 => Self::I64,
+            NUMBER_U64 => Self::U64,
+            NUMBER_F64 => Self::F64,
+            t => panic!("invalid number tag: {t}"),
+        }
+    }
+}
 
 /// Returns the size of the number in bytes.
 pub const fn number_size(tag: u8) -> usize {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -156,6 +156,7 @@ impl From<u8> for NumberTag {
 }
 
 /// Returns the size of the number in bytes.
-pub const fn number_size(tag: u8) -> usize {
-    (tag & 0xF) as usize
+pub fn number_size(data: &[u8]) -> usize {
+    let tag = NumberTag::from(data[0]);
+    (tag as u8 & 0xF) as usize
 }

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -14,6 +14,7 @@
 
 //! Serde support for `ValueRef` and `Builder`.
 
+use std::borrow::Cow;
 use std::fmt::{self, Display};
 
 use serde::de::{DeserializeSeed, MapAccess, SeqAccess, Visitor};
@@ -170,18 +171,18 @@ impl<'de, W: AsMut<Vec<u8>>> Visitor<'de> for BuilderVisitor<'_, W> {
     where
         V: MapAccess<'de>,
     {
-        if let Some(first_key) = visitor.next_key::<&str>()? {
+        if let Some(first_key) = visitor.next_key::<Cow<str>>()? {
             #[cfg(feature = "arbitrary_precision")]
             if first_key == "$serde_json::private::Number" {
-                let v = visitor.next_value::<&str>()?;
-                self.0.add_number_string(v);
+                let v = visitor.next_value::<Cow<str>>()?;
+                self.0.add_number_string(&v);
                 return Ok(());
             }
 
             self.0.begin_object();
 
             // First key-value pair.
-            self.0.add_string(first_key);
+            self.0.add_string(&first_key);
             visitor.next_value_seed(&mut *self.0)?;
 
             // Subsequent key-value pairs.

--- a/src/value.rs
+++ b/src/value.rs
@@ -552,6 +552,13 @@ impl<W: AsMut<Vec<u8>>> Builder<W> {
 
     /// Adds a serde `Number`.
     fn add_serde_number(&mut self, n: &serde_json::Number) {
+        #[cfg(feature = "arbitrary_precision")]
+        {
+            self.add_number_string(n.as_str());
+            return;
+        }
+
+        #[allow(unreachable_code)]
         if let Some(i) = n.as_u64() {
             self.add_u64(i)
         } else if let Some(i) = n.as_i64() {

--- a/src/value_ref.rs
+++ b/src/value_ref.rs
@@ -14,7 +14,6 @@
 
 use std::fmt;
 use std::hash::{Hash, Hasher};
-use std::str::FromStr as _;
 
 use super::*;
 use bytes::Buf;
@@ -357,7 +356,11 @@ impl<'a> NumberRef<'a> {
             NumberTag::I64 => Number::from(data.get_i64_ne()),
             NumberTag::U64 => Number::from(data.get_u64_ne()),
             NumberTag::F64 => Number::from_f64(data.get_f64_ne()).unwrap(),
-            NumberTag::Str => Number::from_str(StringRef::from_bytes(data).as_str()).unwrap(),
+            #[cfg(feature = "arbitrary_precision")]
+            NumberTag::Str => {
+                use std::str::FromStr as _;
+                Number::from_str(StringRef::from_bytes(data).as_str()).unwrap()
+            }
         }
     }
 
@@ -396,6 +399,7 @@ impl<'a> NumberRef<'a> {
             NumberTag::I64 => data.get_i64_ne() as f32,
             NumberTag::U64 => data.get_u64_ne() as f32,
             NumberTag::F64 => data.get_f64_ne() as f32,
+            #[cfg(feature = "arbitrary_precision")]
             NumberTag::Str => (StringRef::from_bytes(data).as_str().parse::<f32>().ok())
                 .filter(|float| float.is_finite())?,
         })

--- a/src/value_ref.rs
+++ b/src/value_ref.rs
@@ -348,15 +348,14 @@ impl NumberRef<'_> {
     /// Dereferences the number.
     pub fn to_number(self) -> Number {
         let mut data = self.data;
-        match data.get_u8() {
-            NUMBER_ZERO => Number::from(0),
-            NUMBER_I8 => Number::from(data.get_i8()),
-            NUMBER_I16 => Number::from(data.get_i16_ne()),
-            NUMBER_I32 => Number::from(data.get_i32_ne()),
-            NUMBER_I64 => Number::from(data.get_i64_ne()),
-            NUMBER_U64 => Number::from(data.get_u64_ne()),
-            NUMBER_F64 => Number::from_f64(data.get_f64_ne()).unwrap(),
-            t => panic!("invalid number tag: {t}"),
+        match NumberTag::from(data.get_u8()) {
+            NumberTag::Zero => Number::from(0),
+            NumberTag::I8 => Number::from(data.get_i8()),
+            NumberTag::I16 => Number::from(data.get_i16_ne()),
+            NumberTag::I32 => Number::from(data.get_i32_ne()),
+            NumberTag::I64 => Number::from(data.get_i64_ne()),
+            NumberTag::U64 => Number::from(data.get_u64_ne()),
+            NumberTag::F64 => Number::from_f64(data.get_f64_ne()).unwrap(),
         }
     }
 
@@ -378,15 +377,14 @@ impl NumberRef<'_> {
     /// Represents the number as f32 if possible. Returns None otherwise.
     pub(crate) fn as_f32(&self) -> Option<f32> {
         let mut data = self.data;
-        Some(match data.get_u8() {
-            NUMBER_ZERO => 0 as f32,
-            NUMBER_I8 => data.get_i8() as f32,
-            NUMBER_I16 => data.get_i16_ne() as f32,
-            NUMBER_I32 => data.get_i32_ne() as f32,
-            NUMBER_I64 => data.get_i64_ne() as f32,
-            NUMBER_U64 => data.get_u64_ne() as f32,
-            NUMBER_F64 => data.get_f64_ne() as f32,
-            t => panic!("invalid number tag: {t}"),
+        Some(match NumberTag::from(data.get_u8()) {
+            NumberTag::Zero => 0 as f32,
+            NumberTag::I8 => data.get_i8() as f32,
+            NumberTag::I16 => data.get_i16_ne() as f32,
+            NumberTag::I32 => data.get_i32_ne() as f32,
+            NumberTag::I64 => data.get_i64_ne() as f32,
+            NumberTag::U64 => data.get_u64_ne() as f32,
+            NumberTag::F64 => data.get_f64_ne() as f32,
         })
     }
 

--- a/src/value_ref.rs
+++ b/src/value_ref.rs
@@ -175,7 +175,7 @@ impl<'a> ValueRef<'a> {
             Entry::TRUE_TAG => Self::Bool(true),
             Entry::NUMBER_TAG => {
                 let ptr = entry.offset();
-                let data = &data[ptr..ptr + 1 + number_size(data[ptr])];
+                let data = &data[ptr..ptr + 1 + number_size(&data[ptr..])];
                 Self::Number(NumberRef { data })
             }
             Entry::STRING_TAG => {


### PR DESCRIPTION
Similar to the feature with the same name in `serde_json`, this ensures the roundtrip of `JSON text -> jsonbb::NumberRef -> JSON text`, which is the dual of `float_roundtrip` introduced in #11.

When the feature is enabled, we will store the number's string representation (from `serde_json::Number::as_str`) as `jsonbb::StringRef` in `jsonbb::NumberRef`. When it's serialized back to JSON text, it will be copied verbatim.

A new fuzz test named `roundtrip_ap` is also added to demonstrate the correctness.

Signed-off-by: Bugen Zhao <i@bugenzhao.com>